### PR TITLE
ALS-2047: handles JSON dictionary return for resource listing

### DIFF
--- a/PicSureClient/Connection.py
+++ b/PicSureClient/Connection.py
@@ -119,12 +119,15 @@ class Connection:
 
     def list(self):
         listing = json.loads(self.getResources())
-        print("+".ljust(39, '-') + '+'.ljust(55, '-'))
-        print("|  Resource UUID".ljust(39, ' ') + '|  Resource Name'.ljust(50, ' '))
-        print("+".ljust(39, '-') + '+'.ljust(55, '-'))
+        print("+".ljust(39, '-') + '+'.ljust(55, '-') + "+")
+        print("|  Resource UUID".ljust(39, ' ') + '|  Resource Name'.ljust(55, ' ') + "|")
+        print("+".ljust(39, '-') + '+'.ljust(55, '-') + "+")
         for rec in listing:
-            print('| ' + rec.ljust(35,' '))
-        print("+".ljust(39, '-') + '+'.ljust(55, '-'))
+            if type(listing) == list:
+                print('| ' + rec.ljust(36, ' ') + " | " + "".ljust(53) + "|")
+            else:
+                print('| ' + rec.ljust(36, ' ') + " | " + listing[rec].ljust(53) + "|")
+        print("+".ljust(39, '-') + '+'.ljust(55, '-') + "+")
 
     def getInfo(self, uuid):
         url = self.url + "info/" + str(uuid)
@@ -169,6 +172,8 @@ class Connection:
             else:
                 ret = content.decode("utf-8")
                 self.resource_uuids = json.loads(ret)
+                if type(self.resource_uuids) == dict:
+                    self.resource_uuids = list(self.resource_uuids.keys())
                 return content.decode("utf-8")
 
     def _api_obj(self):


### PR DESCRIPTION
This creates technical debt that should be addressed once all environments have been upgraded to run the latest PIC-SURE server code which returns a dictionary of {UUID: Name} instead of list of [UUID].

https://hms-dbmi.atlassian.net/browse/ALS-2047