### PR TITLE
Fix queryMetadata() to allow users to load their query

### DIFF
--- a/PicSureClient/Connection.py
+++ b/PicSureClient/Connection.py
@@ -252,9 +252,8 @@ class PicSureConnectionAPI:
         return content
 
     # This operation is handled entirely in PIC-SURE, and does not need a resource connection
-    def queryMetadata(self, query_uuid, resource_uuid):
-        query = {"resourceUUID": resource_uuid, "resourceCredentials": {"BEARER_TOKEN": self._token}}
-        content = self.picsureHttpConnect.get("query/" + query_uuid + "/metadata", data=json.dumps(query))
+    def queryMetadata(self, query_uuid):
+        content = self.picsureHttpConnect.get("query/" + query_uuid + "/metadata", data=json.dumps({}))
         if hasattr(content, 'error') and content.error:
             return json.dumps(content)
         return content

--- a/PicSureClient/Connection.py
+++ b/PicSureClient/Connection.py
@@ -253,7 +253,7 @@ class PicSureConnectionAPI:
 
     # This operation is handled entirely in PIC-SURE, and does not need a resource connection
     def queryMetadata(self, query_uuid):
-        content = self.picsureHttpConnect.get("query/" + query_uuid + "/metadata", data=json.dumps({}))
+        content = self.picsureHttpConnect.get("query/" + query_uuid + "/metadata")
         if hasattr(content, 'error') and content.error:
             return json.dumps(content)
         return content

--- a/PicSureClient/Connection.py
+++ b/PicSureClient/Connection.py
@@ -277,8 +277,8 @@ class PicSureHttpClient:
         else:
             self.http = urllib3.PoolManager()
 
-    def get(self, path, params=None, data=None):
-        return self._request('GET', path, params, data)
+    def get(self, path, params=None):
+        return self._request('GET', path, params)
 
     def post(self, path, params=None, data=None):
         return self._request('POST', path, params, data)


### PR DESCRIPTION
Users can now continue working with a query they exported from the GUI.